### PR TITLE
Avoid to package development files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/_config.yml export-ignore
+/docker-compose.yml export-ignore
+/Dockerfile export-ignore
+/examples export-ignore
+/Makefile export-ignore
+/phpunit.xml export-ignore
+/sonar-project.properties export-ignore
+/tests export-ignore


### PR DESCRIPTION
This PR adds a `.gitattributes` file to ignore development files during Composer packaging.

Currently this package has `104KB` and using this file it will have `44KB` (reduction of ~58%).

Only these files are needed on production:

```
$ find . -type f | sort -n
./composer.json
./README.md
./src/Adapters/AdapterInterface.php
./src/Adapters/RedisAdapter.php
./src/Adapters/SwooleTableAdapter.php
./src/CircuitBreakerException.php
./src/CircuitBreaker.php
./src/GuzzleMiddleware.php
```