### PR TITLE
FIX: Swoole version for PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
 before_install:
   - docker run -d -p 0.0.0.0:6379:6379 --name redis redis:alpine
   - echo "extension=redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-  - echo '' | pecl install swoole
+  - echo '' | pecl install swoole-4.8.12
   - echo "extension=swoole.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 before_script:


### PR DESCRIPTION
A última versão estável (`5.x`) do `Swoole` requer o PHP `>=8.0.0`

https://pecl.php.net/package/swoole

```
0.01s$ echo "extension=redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
0.62s$ echo '' | pecl install swoole
pecl/swoole requires PHP (version >= 8.0.0), installed version is 7.4.33
No valid packages found
install failed
The command "echo '' | pecl install swoole" failed and exited with 1 during .
Your build has been stopped.
```