### PR TITLE
CHORE: Bump http-message version from 1.0 to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "require": {
     "php": "^8.0",
-    "psr/http-message": "^2.0"
+    "psr/http-message": "^1.0"
   },
   "suggest": {
     "ext-swoole": "Required to use Swoole Table Adapter.",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "require": {
     "php": "^8.0",
-    "psr/http-message": "^1.0"
+    "psr/http-message": "^2.0"
   },
   "suggest": {
     "ext-swoole": "Required to use Swoole Table Adapter.",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: '3'
 
 services:
   image:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 services:
   image:


### PR DESCRIPTION
Bump the dependency of php-fig/http-message to 2.0.
~~Despite the change from 1.0 to 2.0, it seems that php-fig does not use Semantic Versioning.~~
(as pointed out by @jdreesen it's a breaking change because of [covariance](https://www.php.net/manual/en/language.oop5.variance.php#language.oop5.variance.covariance),

Only the return types were added to the functions for compatibility with newer PHP versions.

PHP 8.1
![image](https://github.com/user-attachments/assets/1d30e33c-a044-4a98-8533-ad6a2d6ff37b)

PHP 8.2
![image](https://github.com/user-attachments/assets/fa83d016-d31b-4e3f-afb2-9d8af27ca84e)


[Commit from php-fig/http-message](https://github.com/php-fig/http-message/commit/402d35bcb92c70c026d1a6a9883f06b2ead23d71)