### PR TITLE
Prevent indefinite circuit open: validate TTL before incrementing failures

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,16 @@ services:
     image: redis:alpine
     container_name: circuit-breaker-php.redis
 
+  redisinsight:
+    container_name: redis-insight
+    image: redislabs/redisinsight:latest
+    ports:
+      - 8001:8001
+
   app:
     container_name: circuit-breaker-php.app
     image: circuit-breaker-php
+    environment:
+      - REDIS_HOST=circuit-breaker-php.redis
     volumes:
       - ./:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   image:
     container_name: circuit-breaker-php.image

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,36 +1,49 @@
 services:
   image:
-    container_name: circuit-breaker-php.image
+    container_name: circuit-breaker-php-image
     image: circuit-breaker-php
     command: list
     build: .
 
   composer:
-    container_name: circuit-breaker-php.composer
+    container_name: circuit-breaker-php-composer
     image: circuit-breaker-php
     depends_on:
       - image
       - redis
     entrypoint: composer
     environment:
-      - REDIS_HOST=circuit-breaker-php.redis
+      - REDIS_HOST=circuit-breaker-php-redis
     volumes:
       - ./:/app
 
   redis:
     image: redis:alpine
-    container_name: circuit-breaker-php.redis
+    container_name: circuit-breaker-php-redis
+    ports:
+      - 6379:6379
+    networks:
+      - global-default
 
   redisinsight:
-    container_name: redis-insight
+    container_name: circuit-breaker-php-redis-insight
     image: redislabs/redisinsight:latest
     ports:
       - 8001:8001
+      - 5540:5540
+    networks:
+      - global-default
 
   app:
-    container_name: circuit-breaker-php.app
+    container_name: circuit-breaker-php-app
     image: circuit-breaker-php
     environment:
-      - REDIS_HOST=circuit-breaker-php.redis
+      - REDIS_HOST=circuit-breaker-php-redis
     volumes:
       - ./:/app
+    networks:
+      - global-default
+
+networks:
+  global-default:
+    external: true

--- a/examples/RedisAdapterExample.php
+++ b/examples/RedisAdapterExample.php
@@ -7,7 +7,7 @@ use LeoCarmo\CircuitBreaker\Adapters\RedisAdapter;
 
 // Connect to redis
 $redis = new \Redis();
-$redis->connect('localhost', 6379);
+$redis->connect(getenv('REDIS_HOST'), 6379);
 
 $adapter = new RedisAdapter($redis, 'my-product');
 

--- a/examples/RedisClusterAdapterExample.php
+++ b/examples/RedisClusterAdapterExample.php
@@ -7,7 +7,7 @@ use LeoCarmo\CircuitBreaker\Adapters\RedisClusterAdapter;
 
 // Connect to redis
 $redis = new \Redis();
-$redis->connect('localhost', 6379);
+$redis->connect(getenv('REDIS_HOST'), 6379);
 
 $adapter = new RedisClusterAdapter($redis, 'my-product');
 

--- a/src/Adapters/RedisAdapter.php
+++ b/src/Adapters/RedisAdapter.php
@@ -79,15 +79,15 @@ class RedisAdapter implements AdapterInterface
     {
         $serviceName = $this->makeNamespace($service) . ':failures';
 
+        if ($this->redis->ttl($serviceName) === -1) {
+            $this->redis->del($serviceName);
+        }
+
         if (! $this->redis->get($serviceName)) {
             $this->redis->multi();
             $this->redis->incr($serviceName);
             $this->redis->expire($serviceName, $timeWindow);
             return (bool) ($this->redis->exec()[0] ?? false);
-        }
-
-        if ($this->redis->ttl($serviceName) < 0) {
-            $this->redis->del($serviceName);
         }
 
         return (bool) $this->redis->incr($serviceName);

--- a/src/Adapters/RedisAdapter.php
+++ b/src/Adapters/RedisAdapter.php
@@ -86,6 +86,10 @@ class RedisAdapter implements AdapterInterface
             return (bool) ($this->redis->exec()[0] ?? false);
         }
 
+        if ($this->redis->ttl($serviceName) < 0) {
+            $this->redis->del($serviceName);
+        }
+
         return (bool) $this->redis->incr($serviceName);
     }
 

--- a/src/Adapters/RedisAdapter.php
+++ b/src/Adapters/RedisAdapter.php
@@ -79,9 +79,7 @@ class RedisAdapter implements AdapterInterface
     {
         $serviceName = $this->makeNamespace($service) . ':failures';
 
-        if ($this->redis->ttl($serviceName) === -1) {
-            $this->redis->del($serviceName);
-        }
+        $this->resetKeyIfInfiniteTTL($serviceName);
 
         if (! $this->redis->get($serviceName)) {
             $this->redis->multi();

--- a/src/Adapters/RedisAdapter.php
+++ b/src/Adapters/RedisAdapter.php
@@ -149,4 +149,11 @@ class RedisAdapter implements AdapterInterface
     {
         return 'circuit-breaker:' . $this->redisNamespace . ':' . $service;
     }
+
+    protected function resetKeyIfInfiniteTTL(string $service)
+    {
+        if ($this->redis->ttl($service) === -1) {
+            $this->redis->del($service);
+        }
+    }
 }

--- a/src/Adapters/RedisClusterAdapter.php
+++ b/src/Adapters/RedisClusterAdapter.php
@@ -13,6 +13,10 @@ class RedisClusterAdapter extends RedisAdapter
     {
         $serviceName = $this->makeNamespace($service) . ':failures';
 
+        if ($this->redis->ttl($serviceName) === -1) {
+            $this->redis->del($serviceName);
+        }
+
         if (! $this->redis->get($serviceName)) {
             $this->redis->incr($serviceName);
             return (bool) $this->redis->expire($serviceName, $timeWindow);

--- a/src/Adapters/RedisClusterAdapter.php
+++ b/src/Adapters/RedisClusterAdapter.php
@@ -13,9 +13,7 @@ class RedisClusterAdapter extends RedisAdapter
     {
         $serviceName = $this->makeNamespace($service) . ':failures';
 
-        if ($this->redis->ttl($serviceName) === -1) {
-            $this->redis->del($serviceName);
-        }
+        $this->resetKeyIfInfiniteTTL($serviceName);
 
         if (! $this->redis->get($serviceName)) {
             $this->redis->incr($serviceName);

--- a/tests/RedisAdapterTest.php
+++ b/tests/RedisAdapterTest.php
@@ -68,6 +68,38 @@ class RedisAdapterTest extends TestCase
         $adapter->incrementFailure('test-service', 30);
     }
 
+    public function testIncrementFailureWithKeyWithTtl()
+    {
+        $redis = $this->createMock(\Redis::class);
+
+        $adapter = new RedisAdapter($redis, 'test-failure');
+
+        $redis->expects($this->once())
+            ->method('ttl')
+            ->willReturn(20);
+
+        $redis->expects($this->never())
+            ->method('del');
+
+        $redis->expects($this->once())
+            ->method('get')
+            ->willReturn(true);
+
+        $redis->expects($this->never())
+            ->method('multi');
+
+        $redis->expects($this->never())
+            ->method('expire');
+
+        $redis->expects($this->never())
+            ->method('exec');
+
+        $redis->expects($this->once())
+            ->method('incr');
+
+        $adapter->incrementFailure('test-service', 30);
+    }
+
     public function testIncrementFailureWithKeyWithoutTtlIntegratedRedis()
     {
         $redis = new \Redis();

--- a/tests/RedisAdapterTest.php
+++ b/tests/RedisAdapterTest.php
@@ -1,0 +1,94 @@
+<?php declare(strict_types=1);
+
+use LeoCarmo\CircuitBreaker\Adapters\RedisAdapter;
+use PHPUnit\Framework\TestCase;
+
+class RedisAdapterTest extends TestCase
+{
+    public function testIncrementFailure()
+    {
+        $redis = $this->createMock(\Redis::class);
+
+        $adapter = new RedisAdapter($redis, 'test-failure');
+
+        $redis->expects($this->once())
+            ->method('ttl');
+
+        $redis->expects($this->never())
+            ->method('del');
+
+        $redis->expects($this->once())
+            ->method('get')
+            ->willReturn(false);
+
+        $redis->expects($this->once())
+            ->method('multi');
+
+        $redis->expects($this->once())
+            ->method('incr');
+
+        $redis->expects($this->once())
+            ->method('expire');
+
+        $redis->expects($this->once())
+            ->method('exec');
+
+        $adapter->incrementFailure('test-service', 30);
+    }
+
+    public function testIncrementFailureWithKeyWithoutTtl()
+    {
+        $redis = $this->createMock(\Redis::class);
+
+        $adapter = new RedisAdapter($redis, 'test-failure');
+
+        $redis->expects($this->once())
+            ->method('ttl')
+            ->willReturn(-1);
+
+        $redis->expects($this->once())
+            ->method('del');
+
+        $redis->expects($this->once())
+            ->method('get')
+            ->willReturn(false);
+
+        $redis->expects($this->once())
+            ->method('multi');
+
+        $redis->expects($this->once())
+            ->method('incr');
+
+        $redis->expects($this->once())
+            ->method('expire');
+
+        $redis->expects($this->once())
+            ->method('exec');
+
+        $adapter->incrementFailure('test-service', 30);
+    }
+
+    public function testIncrementFailureWithKeyWithoutTtlIntegratedRedis()
+    {
+        $redis = new \Redis();
+        $redis->connect(getenv('REDIS_HOST'));
+
+        $dummy_key = 'circuit-breaker:test-failure:test-service:failures';
+
+        // set dummy key without expire
+        $redis->set($dummy_key, 1);
+        $ttl = $redis->ttl($dummy_key);
+
+        $this->assertEquals(-1, $ttl, 'Dummy key without ttl');
+
+        $adapter = new RedisAdapter($redis, 'test-failure');
+
+        // here, we expect that the dummy key will be removed and a new with ttl will be set
+        $adapter->incrementFailure('test-service', 30);
+
+        $ttl = $redis->ttl($dummy_key);
+
+        $this->assertNotEquals(-1, $ttl, 'Dummy key with ttl');
+        $this->assertGreaterThan(1, $ttl, 'Dummy key more than 1s ttl');
+    }
+}


### PR DESCRIPTION
We found a bug in high-throughput "put" applications when both failure and success counters are being set at the same time. When registering a failure, we first check if the key already exists. If it does, we simply increment it. However, between the get and the increment operations, a success event may delete the key. If that happens, the increment operation will recreate the key without a TTL, causing the circuit to remain open indefinitely.

To fix this, we now check whether the key has an active TTL. If it doesn't, the key will be deleted instead of being incremented. In the future, this logic will be replaced with an atomic get-and-increment operation to fully prevent race conditions. For now, this fix addresses the issue.